### PR TITLE
Trigger handlers when events are fired on child elements

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -50,8 +50,7 @@
     "limitComments": true
   },
   "missing_fat_arrows": {
-    "level": "warn",
-    "is_strict": false
+    "level": "ignore"
   },
   "newlines_after_classes": {
     "value": 3,

--- a/src/features/confirm.coffee
+++ b/src/features/confirm.coffee
@@ -3,7 +3,7 @@
 { fire, stopEverything } = Rails
 
 Rails.handleConfirm = (e) ->
-  stopEverything(e) unless allowAction(e.target)
+  stopEverything(e) unless allowAction(this)
 
 # For 'data-confirm' attribute:
 # - Fires `confirm` event

--- a/src/features/method.coffee
+++ b/src/features/method.coffee
@@ -5,7 +5,7 @@
 # Handles "data-method" on links such as:
 # <a href="/users/5" data-method="delete" rel="nofollow" data-confirm="Are you sure?">Delete</a>
 Rails.handleMethod = (e) ->
-  link = e.target
+  link = this
   method = link.getAttribute('data-method')
   return unless method
 

--- a/src/features/remote.coffee
+++ b/src/features/remote.coffee
@@ -14,7 +14,7 @@ isRemote = (element) ->
 
 # Submits "remote" forms and links with ajax
 Rails.handleRemote = (e) ->
-  element = e.target
+  element = this
 
   return true unless isRemote(element)
   unless fire(element, 'ajax:before')
@@ -74,7 +74,7 @@ Rails.handleRemote = (e) ->
 # Check whether any required fields are empty
 # In both ajax mode and normal mode
 Rails.validateForm = (e) ->
-  form = e.target
+  form = this
   return if form.noValidate or getData(form, 'ujs:formnovalidate-button')
   # Skip other logic when required values are missing or file upload is present
   blankRequiredInputs = blankInputs(form, Rails.requiredInputSelector, false)
@@ -82,7 +82,7 @@ Rails.validateForm = (e) ->
     stopEverything(e)
 
 Rails.formSubmitButtonClick = (e) ->
-  button = e.target
+  button = this
   form = button.form
   return unless form
   # Register the pressed submit button
@@ -93,7 +93,7 @@ Rails.formSubmitButtonClick = (e) ->
   setData(form, 'ujs:submit-button-formmethod', button.getAttribute('formmethod'))
 
 Rails.handleMetaClick = (e) ->
-  link = e.target
+  link = this
   method = (link.getAttribute('data-method') or 'GET').toUpperCase()
   data = link.getAttribute('data-params')
   metaClick = e.metaKey or e.ctrlKey

--- a/src/utils/event.coffee
+++ b/src/utils/event.coffee
@@ -33,7 +33,8 @@ Rails.stopEverything = (e) ->
 
 Rails.delegate = (element, selector, eventType, handler) ->
   element.addEventListener eventType, (e) ->
-    if matches(e.target, selector)
-      if handler.call(e.target, e) == false
-        e.preventDefault()
-        e.stopPropagation()
+    target = e.target
+    target = target.parentNode until not (target instanceof Element) or matches(target, selector)
+    if target instanceof Element and handler.call(target, e) == false
+      e.preventDefault()
+      e.stopPropagation()

--- a/test/public/test/data-confirm.js
+++ b/test/public/test/data-confirm.js
@@ -263,3 +263,26 @@ asyncTest('a button inside a form only confirms once', 1, function() {
   ok(confirmations === 1, 'confirmation counter should be 1, but it was ' + confirmations)
   start()
 })
+
+asyncTest('clicking on the children of a link should also trigger a confirm', 6, function() {
+  var message
+  // auto-confirm:
+  window.confirm = function(msg) { message = msg; return true }
+
+  $('a[data-confirm]')
+    .html('<strong>Click me</strong>')
+    .bindNative('confirm:complete', function(e, data) {
+      App.assertCallbackInvoked('confirm:complete')
+      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+    })
+    .bindNative('ajax:success', function(e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success')
+      App.assertRequestPath(data, '/echo')
+      App.assertGetRequest(data)
+
+      equal(message, 'Are you absolutely sure?')
+      start()
+    })
+    .find('strong')
+    .triggerNative('click')
+})

--- a/test/public/test/data-method.js
+++ b/test/public/test/data-method.js
@@ -29,6 +29,16 @@ asyncTest('link with "data-method" set to "delete"', 3, function() {
   })
 })
 
+asyncTest('click on the child of link with "data-method"', 3, function() {
+  $(document).bind('iframe:loaded', function(e, data) {
+    equal(data.REQUEST_METHOD, 'DELETE')
+    strictEqual(data.params.authenticity_token, undefined)
+    strictEqual(data.HTTP_X_CSRF_TOKEN, undefined)
+    start()
+  })
+  $('#qunit-fixture a').html('<strong>destroy!</strong>').find('strong').triggerNative('click')
+})
+
 asyncTest('link with "data-method" and CSRF', 1, function() {
   $('#qunit-fixture')
     .append('<meta name="csrf-param" content="authenticity_token"/>')


### PR DESCRIPTION
Fix the bug that ujs won't handle events when clicking on the following link

    <a data-confirm="Sure?"><strong>Destroy</strong></a>

It's a mistake by me, which is quite disastrous.