### PR TITLE
Fix confusing error message that mentions jquery-ujs instead of rails-jus

### DIFF
--- a/src/rails-ujs.coffee
+++ b/src/rails-ujs.coffee
@@ -27,7 +27,7 @@ if jQuery? and not jQuery.rails
 Rails.start = ->
   # Cut down on the number of issues from people inadvertently including jquery_ujs twice
   # by detecting and raising an error when it happens.
-  throw new Error('jquery-ujs has already been loaded!') if window._rails_loaded
+  throw new Error('rails-ujs has already been loaded!') if window._rails_loaded
 
   # This event works the same as the load event, except that it fires every
   # time the page is loaded.


### PR DESCRIPTION
I saw this error in my browser console and was surprised to see jquery mentioned, considering that I don't use it.