### PR TITLE
Address that rails-ujs gem is not yet published

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation using the rails-ujs gem
 For automated installation in Rails, use the "rails-ujs" gem. Place this in your Gemfile:
 
 ```ruby
-gem 'rails-ujs'
+gem 'rails-ujs', git: 'https://github.com/rails/rails-ujs.git'
 ```
 
 And run:


### PR DESCRIPTION
The README currently reads to install the gem via

```ruby
gem 'rails-ujs'
```

but this is wrong since this would attempt to install [this gem](https://rubygems.org/gems/rails-ujs) which is an old gem published by someone else.